### PR TITLE
[(UTC +8:00) 2017-12-12 18:35] See below

### DIFF
--- a/compiler/ckx_ast_node.cpp
+++ b/compiler/ckx_ast_node.cpp
@@ -22,15 +22,14 @@
 namespace ckx
 {
 
-ckx_ast_node::ckx_ast_node(saber_ptr<ckx_token> _at_token) :
+ckx_ast_node::ckx_ast_node(ckx_token _at_token) :
     at_token(_at_token)
 {}
 
-saber_ptr<ckx_token> ckx_ast_node::get_at_token()
+ckx_token ckx_ast_node::get_at_token()
 { return at_token; }
 
-ckx_ast_translation_unit::ckx_ast_translation_unit(
-        saber_ptr<ckx_token> _at_token) :
+ckx_ast_translation_unit::ckx_ast_translation_unit(ckx_token _at_token) :
     ckx_ast_node(_at_token),
     global_table(new ckx_env(nullptr))
 {}
@@ -51,13 +50,13 @@ ckx_ast_translation_unit::add_new_stmt(ckx_ast_stmt *_stmt)
     stmts.push_back(_stmt);
 }
 
-ckx_ast_stmt::ckx_ast_stmt(saber_ptr<ckx_token> _at_token) :
+ckx_ast_stmt::ckx_ast_stmt(ckx_token _at_token) :
     ckx_ast_node(_at_token)
 {}
 
 ckx_ast_stmt::~ckx_ast_stmt() {}
 
-ckx_ast_compound_stmt::ckx_ast_compound_stmt(saber_ptr<ckx_token> _at_token) :
+ckx_ast_compound_stmt::ckx_ast_compound_stmt(ckx_token _at_token) :
     ckx_ast_stmt(_at_token)
 {}
 
@@ -73,7 +72,7 @@ ckx_ast_compound_stmt::add_new_stmt(ckx_ast_stmt* _stmt)
     stmts.push_back(_stmt);
 }
 
-ckx_ast_if_stmt::ckx_ast_if_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_if_stmt::ckx_ast_if_stmt(ckx_token _at_token,
                                  ckx_ast_expr *_condition,
                                  ckx_ast_stmt *_then_clause,
                                  ckx_ast_stmt *_else_clause) :
@@ -90,7 +89,7 @@ ckx_ast_if_stmt::~ckx_ast_if_stmt()
     delete else_clause;
 }
 
-ckx_ast_while_stmt::ckx_ast_while_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_while_stmt::ckx_ast_while_stmt(ckx_token _at_token,
                                        ckx_ast_expr *_condition,
                                        ckx_ast_stmt *_clause) :
     ckx_ast_stmt(_at_token),
@@ -104,7 +103,7 @@ ckx_ast_while_stmt::~ckx_ast_while_stmt()
     delete clause;
 }
 
-ckx_ast_do_while_stmt::ckx_ast_do_while_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_do_while_stmt::ckx_ast_do_while_stmt(ckx_token _at_token,
                                              ckx_ast_expr *_condition,
                                              ckx_ast_stmt *_clause) :
     ckx_ast_stmt(_at_token),
@@ -118,7 +117,7 @@ ckx_ast_do_while_stmt::~ckx_ast_do_while_stmt()
     delete clause;
 }
 
-ckx_ast_for_stmt::ckx_ast_for_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_for_stmt::ckx_ast_for_stmt(ckx_token _at_token,
                                    ckx_ast_expr *_init,
                                    ckx_ast_expr *_condition,
                                    ckx_ast_expr *_incr,
@@ -139,17 +138,17 @@ ckx_ast_for_stmt::~ckx_ast_for_stmt()
 }
 
 
-ckx_ast_break_stmt::ckx_ast_break_stmt(saber_ptr<ckx_token> _at_token) :
+ckx_ast_break_stmt::ckx_ast_break_stmt(ckx_token _at_token) :
     ckx_ast_stmt(_at_token)
 {}
 
 
-ckx_ast_continue_stmt::ckx_ast_continue_stmt(saber_ptr<ckx_token> _at_token) :
+ckx_ast_continue_stmt::ckx_ast_continue_stmt(ckx_token _at_token) :
     ckx_ast_stmt(_at_token)
 {}
 
 
-ckx_ast_return_stmt::ckx_ast_return_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_return_stmt::ckx_ast_return_stmt(ckx_token _at_token,
                                          ckx_ast_expr *_return_expr) :
     ckx_ast_stmt(_at_token),
     return_expr(_return_expr)
@@ -162,7 +161,7 @@ ckx_ast_return_stmt::~ckx_ast_return_stmt()
 
 ckx_ast_decl_stmt::init_decl::~init_decl() { delete init; }
 
-ckx_ast_decl_stmt::ckx_ast_decl_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_decl_stmt::ckx_ast_decl_stmt(ckx_token _at_token,
         saber_ptr<ckx_type> _type,
         saber::vector<init_decl> &&_decls) :
     ckx_ast_stmt(_at_token),
@@ -171,7 +170,7 @@ ckx_ast_decl_stmt::ckx_ast_decl_stmt(saber_ptr<ckx_token> _at_token,
 {}
 
 
-ckx_ast_expr_stmt::ckx_ast_expr_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_expr_stmt::ckx_ast_expr_stmt(ckx_token _at_token,
                                      ckx_ast_expr *_expr) :
     ckx_ast_stmt(_at_token),
     expr(_expr)
@@ -185,7 +184,7 @@ ckx_ast_expr_stmt::~ckx_ast_expr_stmt()
 
 
 ckx_ast_func_stmt::ckx_ast_func_stmt(
-        saber_ptr<ckx_token> _at_token,
+        ckx_token _at_token,
         saber_string_view _name,
         saber::vector<ckx_ast_func_stmt::param_decl> &&_param_decls,
         saber_ptr<ckx_type> _ret_type,
@@ -204,7 +203,7 @@ ckx_ast_func_stmt::~ckx_ast_func_stmt()
 
 
 
-ckx_ast_struct_stmt::ckx_ast_struct_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_struct_stmt::ckx_ast_struct_stmt(ckx_token _at_token,
                                          saber_string_view _name,
                                          saber::vector<field> &&_fields) :
     ckx_ast_stmt(_at_token),
@@ -221,7 +220,7 @@ ckx_ast_struct_stmt::get_fields() const
 }
 
 
-ckx_ast_variant_stmt::ckx_ast_variant_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_variant_stmt::ckx_ast_variant_stmt(ckx_token _at_token,
                                            saber_string_view _name,
                                            saber::vector<field> &&_fields) :
     ckx_ast_stmt(_at_token),
@@ -238,7 +237,7 @@ ckx_ast_variant_stmt::get_fields() const
 }
 
 
-ckx_ast_alias_stmt::ckx_ast_alias_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_alias_stmt::ckx_ast_alias_stmt(ckx_token _at_token,
                                        saber_string_view _name,
                                        saber_ptr<ckx_type> _type) :
     ckx_ast_stmt(_at_token),
@@ -247,7 +246,7 @@ ckx_ast_alias_stmt::ckx_ast_alias_stmt(saber_ptr<ckx_token> _at_token,
 {}
 
 
-ckx_ast_enum_stmt::ckx_ast_enum_stmt(saber_ptr<ckx_token> _at_token,
+ckx_ast_enum_stmt::ckx_ast_enum_stmt(ckx_token _at_token,
                                      saber_string_view _name,
                                      saber::vector<enumerator> &&_enumerators) :
     ckx_ast_stmt(_at_token),
@@ -264,13 +263,13 @@ ckx_ast_enum_stmt::get_enumerators() const
 }
 
 
-ckx_ast_expr::ckx_ast_expr(saber_ptr<ckx_token> _at_token) :
+ckx_ast_expr::ckx_ast_expr(ckx_token _at_token) :
     ckx_ast_node(_at_token)
 {}
 
 ckx_ast_expr::~ckx_ast_expr() {}
 
-ckx_ast_binary_expr::ckx_ast_binary_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_binary_expr::ckx_ast_binary_expr(ckx_token _at_token,
                                          ckx_op _opercode,
                                          ckx_ast_expr *_loperand,
                                          ckx_ast_expr *_roperand) :
@@ -286,7 +285,7 @@ ckx_ast_binary_expr::~ckx_ast_binary_expr()
     delete roperand;
 }
 
-ckx_ast_unary_expr::ckx_ast_unary_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_unary_expr::ckx_ast_unary_expr(ckx_token _at_token,
                                        ckx_op _opercode,
                                        ckx_ast_expr *_operand) :
     ckx_ast_expr(_at_token),
@@ -299,7 +298,7 @@ ckx_ast_unary_expr::~ckx_ast_unary_expr()
     delete operand;
 }
 
-ckx_ast_subscript_expr::ckx_ast_subscript_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_subscript_expr::ckx_ast_subscript_expr(ckx_token _at_token,
                                                ckx_ast_expr *_base,
                                                ckx_ast_expr *_subscript) :
     ckx_ast_expr(_at_token),
@@ -313,7 +312,7 @@ ckx_ast_subscript_expr::~ckx_ast_subscript_expr()
     delete subscript;
 }
 
-ckx_ast_invoke_expr::ckx_ast_invoke_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_invoke_expr::ckx_ast_invoke_expr(ckx_token _at_token,
                                          ckx_ast_expr *_invokable,
                                          saber::vector<ckx_ast_expr*> &&_args) :
     ckx_ast_expr(_at_token),
@@ -328,7 +327,7 @@ ckx_ast_invoke_expr::~ckx_ast_invoke_expr()
     for (auto& arg : args) delete arg;
 }
 
-ckx_ast_extract_expr::ckx_ast_extract_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_extract_expr::ckx_ast_extract_expr(ckx_token _at_token,
                                            ckx_ast_expr *_extracted,
                                            saber_string_view _field_name) :
     ckx_ast_expr(_at_token),
@@ -342,7 +341,7 @@ ckx_ast_extract_expr::~ckx_ast_extract_expr()
 }
 
 ckx_ast_enumerator_expr::ckx_ast_enumerator_expr(
-        saber_ptr<ckx_token> _at_token,
+        ckx_token _at_token,
         saber_string_view _enum_name,
         saber_string_view _enumerator_name) :
     ckx_ast_expr(_at_token),
@@ -350,7 +349,7 @@ ckx_ast_enumerator_expr::ckx_ast_enumerator_expr(
     enumerator_name(_enumerator_name)
 {}
 
-ckx_ast_cond_expr::ckx_ast_cond_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_cond_expr::ckx_ast_cond_expr(ckx_token _at_token,
                                      ckx_ast_expr *_cond_expr,
                                      ckx_ast_expr *_then_expr,
                                      ckx_ast_expr *_else_expr) :
@@ -367,7 +366,7 @@ ckx_ast_cond_expr::~ckx_ast_cond_expr()
     delete else_expr;
 }
 
-ckx_ast_id_expr::ckx_ast_id_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_id_expr::ckx_ast_id_expr(ckx_token _at_token,
                                  saber_string_view _name) :
     ckx_ast_expr(_at_token),
     name(_name)
@@ -376,7 +375,7 @@ ckx_ast_id_expr::ckx_ast_id_expr(saber_ptr<ckx_token> _at_token,
 ckx_ast_id_expr::~ckx_ast_id_expr()
 {}
 
-ckx_ast_cast_expr::ckx_ast_cast_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_cast_expr::ckx_ast_cast_expr(ckx_token _at_token,
                                      castop _op,
                                      saber_ptr<ckx_type> _desired_type,
                                      ckx_ast_expr *_expr) :
@@ -391,25 +390,25 @@ ckx_ast_cast_expr::~ckx_ast_cast_expr()
     delete expr;
 }
 
-ckx_ast_sizeof_expr::ckx_ast_sizeof_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_sizeof_expr::ckx_ast_sizeof_expr(ckx_token _at_token,
                                          saber_ptr<ckx_type> _type) :
     ckx_ast_expr(_at_token),
     type(_type)
 {}
 
-ckx_ast_vi_literal_expr::ckx_ast_vi_literal_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_vi_literal_expr::ckx_ast_vi_literal_expr(ckx_token _at_token,
                                                  qint64 _val) :
     ckx_ast_expr(_at_token),
     val(_val)
 {}
 
-ckx_ast_vr_literal_expr::ckx_ast_vr_literal_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_vr_literal_expr::ckx_ast_vr_literal_expr(ckx_token _at_token,
                                                  qreal _val) :
     ckx_ast_expr(_at_token),
     val(_val)
 {}
 
-ckx_ast_array_expr::ckx_ast_array_expr(saber_ptr<ckx_token> _at_token,
+ckx_ast_array_expr::ckx_ast_array_expr(ckx_token _at_token,
                                        saber_ptr<ckx_type> _array_of_type) :
     ckx_ast_expr(_at_token),
     array_of_type(_array_of_type)

--- a/compiler/ckx_ast_node.hpp
+++ b/compiler/ckx_ast_node.hpp
@@ -41,20 +41,20 @@ using saber::saber_ptr;
 interface ckx_ast_node
 {
 public:
-    explicit ckx_ast_node(saber_ptr<ckx_token> _at_token);
+    explicit ckx_ast_node(ckx_token _at_token);
     ~ckx_ast_node() = default;
 
-    saber_ptr<ckx_token> get_at_token();
+    ckx_token get_at_token();
     virtual void ast_dump(we::we_file_writer& _writer, quint16 _level) = 0;
 
 private:
-    saber_ptr<ckx_token> at_token;
+    const ckx_token at_token;
 };
 
 class ckx_ast_translation_unit final implements ckx_ast_node
 {
 public:
-    explicit ckx_ast_translation_unit(saber_ptr<ckx_token> _at_token);
+    explicit ckx_ast_translation_unit(ckx_token _at_token);
     ~ckx_ast_translation_unit();
 
     void add_new_stmt(ckx_ast_stmt *_stmt);
@@ -68,7 +68,7 @@ private:
 interface ckx_ast_stmt implements ckx_ast_node
 {
 public:
-    explicit ckx_ast_stmt(saber_ptr<ckx_token> _at_token);
+    explicit ckx_ast_stmt(ckx_token _at_token);
     virtual ~ckx_ast_stmt() = 0;
 
     virtual void ast_dump(we::we_file_writer& _writer, quint16 _level) = 0;
@@ -84,7 +84,7 @@ public:
 class ckx_ast_compound_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_compound_stmt(saber_ptr<ckx_token> _at_token);
+    ckx_ast_compound_stmt(ckx_token _at_token);
     ~ckx_ast_compound_stmt() override final;
 
     void add_new_stmt(ckx_ast_stmt *_stmt);
@@ -97,7 +97,7 @@ private:
 class ckx_ast_if_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_if_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_if_stmt(ckx_token _at_token,
                     ckx_ast_expr* _condition,
                     ckx_ast_stmt* _then_clause,
                     ckx_ast_stmt* _else_clause);
@@ -114,7 +114,7 @@ private:
 class ckx_ast_while_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_while_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_while_stmt(ckx_token _at_token,
                        ckx_ast_expr *_condition,
                        ckx_ast_stmt *_clause);
     ~ckx_ast_while_stmt() override final;
@@ -129,7 +129,7 @@ private:
 class ckx_ast_do_while_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_do_while_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_do_while_stmt(ckx_token _at_token,
                           ckx_ast_expr *_condition,
                           ckx_ast_stmt *_clause);
     ~ckx_ast_do_while_stmt() override final;
@@ -144,7 +144,7 @@ private:
 class ckx_ast_for_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_for_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_for_stmt(ckx_token _at_token,
                      ckx_ast_expr *_init,
                      ckx_ast_expr *_condition,
                      ckx_ast_expr *_incr,
@@ -163,7 +163,7 @@ private:
 class ckx_ast_break_stmt final implements ckx_ast_stmt
 {
 public:
-    explicit ckx_ast_break_stmt(saber_ptr<ckx_token> _at_token);
+    explicit ckx_ast_break_stmt(ckx_token _at_token);
     ~ckx_ast_break_stmt() override final = default;
 
     void ast_dump(we::we_file_writer& _writer, quint16 _level) override final;
@@ -172,7 +172,7 @@ public:
 class ckx_ast_continue_stmt final implements ckx_ast_stmt
 {
 public:
-    explicit ckx_ast_continue_stmt(saber_ptr<ckx_token> _at_token);
+    explicit ckx_ast_continue_stmt(ckx_token _at_token);
     ~ckx_ast_continue_stmt() override final = default;
 
     void ast_dump(we::we_file_writer& _writer, quint16 _level) override final;
@@ -181,7 +181,7 @@ public:
 class ckx_ast_return_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_return_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_return_stmt(ckx_token _at_token,
                         ckx_ast_expr* _return_expr);
     ~ckx_ast_return_stmt() override final;
 
@@ -209,7 +209,7 @@ public:
         ckx_ast_expr* init;
     };
 
-    explicit ckx_ast_decl_stmt(saber_ptr<ckx_token> _at_token,
+    explicit ckx_ast_decl_stmt(ckx_token _at_token,
                                saber_ptr<ckx_type> _type,
                                saber::vector<init_decl>&& _decls);
     ~ckx_ast_decl_stmt() override final = default;
@@ -224,7 +224,7 @@ private:
 class ckx_ast_expr_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_expr_stmt(saber_ptr<ckx_token> _at_token, ckx_ast_expr* _expr);
+    ckx_ast_expr_stmt(ckx_token _at_token, ckx_ast_expr* _expr);
     ~ckx_ast_expr_stmt() override final;
 
     void ast_dump(we::we_file_writer& _writer, quint16 _level) override final;
@@ -244,7 +244,7 @@ public:
         saber_string_view name;
     };
 
-    ckx_ast_func_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_func_stmt(ckx_token _at_token,
                       saber_string_view _name,
                       saber::vector<param_decl>&& _param_decls,
                       saber_ptr<ckx_type> _ret_type,
@@ -271,7 +271,7 @@ public:
         saber_string_view name;
     };
 
-    ckx_ast_struct_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_struct_stmt(ckx_token _at_token,
                         saber_string_view _name,
                         saber::vector<field>&& _fields);
     ~ckx_ast_struct_stmt() override final;
@@ -295,7 +295,7 @@ public:
         saber_string_view name;
     };
 
-    ckx_ast_variant_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_variant_stmt(ckx_token _at_token,
                          saber_string_view _name,
                          saber::vector<field>&& _fields);
     ~ckx_ast_variant_stmt() override final;
@@ -319,7 +319,7 @@ public:
         qint64 value;
     };
 
-    ckx_ast_enum_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_enum_stmt(ckx_token _at_token,
                       saber_string_view _name,
                       saber::vector<enumerator>&& _enumerators);
     ~ckx_ast_enum_stmt() override final;
@@ -335,7 +335,7 @@ private:
 class ckx_ast_alias_stmt final implements ckx_ast_stmt
 {
 public:
-    ckx_ast_alias_stmt(saber_ptr<ckx_token> _at_token,
+    ckx_ast_alias_stmt(ckx_token _at_token,
                        saber_string_view _name,
                        saber_ptr<ckx_type> _type);
     ~ckx_ast_alias_stmt() override final = default;
@@ -350,7 +350,7 @@ private:
 interface ckx_ast_expr implements ckx_ast_node
 {
 public:
-    ckx_ast_expr(saber_ptr<ckx_token> _at_token);
+    ckx_ast_expr(ckx_token _at_token);
     virtual ~ckx_ast_expr() = 0;
 
     virtual void ast_dump(we::we_file_writer& _writer, quint16 _level) = 0;
@@ -359,7 +359,7 @@ public:
 class ckx_ast_binary_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_binary_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_binary_expr(ckx_token _at_token,
                         ckx_op _opercode,
                         ckx_ast_expr *_loperand,
                         ckx_ast_expr *_roperand);
@@ -376,7 +376,7 @@ private:
 class ckx_ast_unary_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_unary_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_unary_expr(ckx_token _at_token,
                        ckx_op _opercode,
                        ckx_ast_expr *_operand);
     ~ckx_ast_unary_expr() override final;
@@ -391,7 +391,7 @@ private:
 class ckx_ast_subscript_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_subscript_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_subscript_expr(ckx_token _at_token,
                            ckx_ast_expr *_base,
                            ckx_ast_expr *_subscript);
     ~ckx_ast_subscript_expr() override final;
@@ -406,7 +406,7 @@ private:
 class ckx_ast_invoke_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_invoke_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_invoke_expr(ckx_token _at_token,
                         ckx_ast_expr *_invokable,
                         saber::vector<ckx_ast_expr*> &&_args);
     ~ckx_ast_invoke_expr() override final;
@@ -421,7 +421,7 @@ private:
 class ckx_ast_extract_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_extract_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_extract_expr(ckx_token _at_token,
                          ckx_ast_expr *_extracted,
                          saber_string_view _field_name);
     ~ckx_ast_extract_expr() override final;
@@ -436,7 +436,7 @@ private:
 class ckx_ast_enumerator_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_enumerator_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_enumerator_expr(ckx_token _at_token,
                             saber_string_view _enum_name,
                             saber_string_view _enumerator_name);
     ~ckx_ast_enumerator_expr() override final = default;
@@ -451,7 +451,7 @@ private:
 class ckx_ast_cond_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_cond_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_cond_expr(ckx_token _at_token,
                       ckx_ast_expr* _cond_expr,
                       ckx_ast_expr* _then_expr,
                       ckx_ast_expr* _else_expr);
@@ -468,7 +468,7 @@ private:
 class ckx_ast_id_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_id_expr(saber_ptr<ckx_token> _at_token, saber_string_view _name);
+    ckx_ast_id_expr(ckx_token _at_token, saber_string_view _name);
     ~ckx_ast_id_expr() override final;
 
     void ast_dump(we::we_file_writer& _writer, quint16 _level) override final;
@@ -483,7 +483,7 @@ public:
     enum class castop : qchar
     { cst_static, cst_const, cst_reinterpret, cst_ckx };
 
-    ckx_ast_cast_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_cast_expr(ckx_token _at_token,
                       castop _op,
                       saber_ptr<ckx_type> _desired_type,
                       ckx_ast_expr* _expr);
@@ -500,7 +500,7 @@ private:
 class ckx_ast_sizeof_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_sizeof_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_sizeof_expr(ckx_token _at_token,
                         saber_ptr<ckx_type> _type);
     ~ckx_ast_sizeof_expr() override final = default;
 
@@ -513,7 +513,7 @@ private:
 class ckx_ast_vi_literal_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_vi_literal_expr(saber_ptr<ckx_token> _at_token, qint64 _val);
+    ckx_ast_vi_literal_expr(ckx_token _at_token, qint64 _val);
     ~ckx_ast_vi_literal_expr() override final = default;
 
     void ast_dump(we::we_file_writer &_writer, quint16 _level) override final;
@@ -525,7 +525,7 @@ private:
 class ckx_ast_vr_literal_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_vr_literal_expr(saber_ptr<ckx_token> _at_token, qreal _val);
+    ckx_ast_vr_literal_expr(ckx_token _at_token, qreal _val);
     ~ckx_ast_vr_literal_expr() override final = default;
 
     void ast_dump(we::we_file_writer &_writer, quint16 _level) override final;
@@ -537,7 +537,7 @@ private:
 class ckx_ast_array_expr final implements ckx_ast_expr
 {
 public:
-    ckx_ast_array_expr(saber_ptr<ckx_token> _at_token,
+    ckx_ast_array_expr(ckx_token _at_token,
                        saber_ptr<ckx_type> _array_of_type);
     ~ckx_ast_array_expr() override final;
 

--- a/compiler/ckx_parser_impl.hpp
+++ b/compiler/ckx_parser_impl.hpp
@@ -98,12 +98,12 @@ protected:
     saber_ptr<ckx_type> parse_type();
 
     /// @brief utility functions
-    bool id_is_typename(saber_ptr<ckx_token> _token);
+    bool id_is_typename(ckx_token _token);
 
     /// @brief token-access functions
     /// simply encapsuled token-stream again.
-    inline  saber_ptr<ckx_token>  current_token();
-    inline  saber_ptr<ckx_token>  peek_next_token();
+    inline  ckx_token  current_token();
+    inline  ckx_token  peek_next_token();
     inline  void                  next_token();
 
     inline  bool  expect_n_eat(ckx_token::type _token_type,

--- a/compiler/ckx_token.cpp
+++ b/compiler/ckx_token.cpp
@@ -25,59 +25,49 @@ namespace ckx
 {
 
 ckx_token::ckx_token(const qcoord &_pos, type _operator) :
-    ckx_token(_pos)
-{
-    this->token_type = _operator;
-}
+    token_type(_operator),
+    v{.i64=0},
+    position(_pos)
+{}
 
 ckx_token::ckx_token(const qcoord &_pos, qint64 _int_literal) :
-    ckx_token(_pos)
-{
-    this->token_type = type::tk_vi_literal;
-    this->v.i64 = _int_literal;
-}
+    token_type(type::tk_vi_literal),
+    v{.i64=_int_literal},
+    position(_pos)
+{}
 
 ckx_token::ckx_token(const qcoord &_pos, quint64 _unsigned_literal) :
-    ckx_token(_pos)
-{
-    this->token_type = type::tk_vu_literal;
-    this->v.u64 = _unsigned_literal;
-}
+    token_type(type::tk_vr_literal),
+    v{.u64=_unsigned_literal},
+    position(_pos)
+{}
 
 ckx_token::ckx_token(const qcoord &_pos, qreal _real_literal) :
-    ckx_token(_pos)
-{
-    this->token_type = type::tk_vr_literal;
-    this->v.r = _real_literal;
-}
+    token_type(type::tk_vr_literal),
+    v{.r=_real_literal},
+    position(_pos)
+{}
 
 ckx_token::ckx_token(const qcoord &_pos, qchar _char_literal) :
-    ckx_token(_pos)
-{
-    this->token_type = type::tk_vchar_literal;
-    this->v.ch = _char_literal;
-}
+    token_type(type::tk_vchar_literal),
+    v{.ch=_char_literal},
+    position(_pos)
+{}
 
 ckx_token::ckx_token(const qcoord &_pos, saber_string_view _id) :
-    ckx_token(_pos)
-{
-    token_type = type::tk_id;
-    str = _id;
-}
+    token_type(type::tk_id),
+    v{.i64=0},
+    str(_id),
+    position(_pos)
+{}
 
 ckx_token::~ckx_token()
-{
-}
-
-ckx_token::ckx_token(const qcoord &_coord) :
-    position(_coord),
-    str(saber_string_pool::create_view(""))
 {}
 
 
-saber_string to_string_helper(saber_ptr<ckx_token> _token)
+saber_string to_string_helper(ckx_token _token)
 {
-    switch (_token->token_type)
+    switch (_token.token_type)
     {
 #   define GG2LEX(X, Y) \
     case ckx_token::type::tk_##Y: return X;
@@ -87,16 +77,16 @@ saber_string to_string_helper(saber_ptr<ckx_token> _token)
 #   undef GG2LEX
 #   undef GGLEX
     case ckx_token::type::tk_vi_literal:
-        return saber::to_string_helper(_token->v.i64);
+        return saber::to_string_helper(_token.v.i64);
     case ckx_token::type::tk_vr_literal:
-        return saber::to_string_helper(_token->v.r);
+        return saber::to_string_helper(_token.v.r);
     case ckx_token::type::tk_vu_literal:
-        return saber::to_string_helper(_token->v.u64);
+        return saber::to_string_helper(_token.v.u64);
     case ckx_token::type::tk_vchar_literal:
-        return saber::to_string_helper(char(_token->v.ch));
+        return saber::to_string_helper(char(_token.v.ch));
     case ckx_token::type::tk_string_literal:
     case ckx_token::type::tk_id:
-        return saber::to_string_helper(_token->str);
+        return saber::to_string_helper(_token.str);
     case ckx_token::type::tk_eoi:
         return "EOI";
     }

--- a/compiler/ckx_token.hpp
+++ b/compiler/ckx_token.hpp
@@ -149,23 +149,20 @@ open_class ckx_token
     ckx_token(const qcoord& _pos, saber_string_view _id);
 
     ckx_token() = delete;
-    ckx_token(const ckx_token&) = delete;
-    ckx_token& operator= (const ckx_token&) = delete;
-
     ~ckx_token();
 
     type token_type;
 
-    variant
+    variant token_value
     {
-        qchar ch;
-        qint64 i64;
-        quint64 u64;
-        qreal r;
+        const qchar ch;
+        const qint64 i64;
+        const quint64 u64;
+        const qreal r;
     } v;
+    const saber_string_view str = saber_string_pool::create_view("");
 
-    qcoord position;
-    saber_string_view str;
+    const qcoord position;
 
 private:
     // This constructor reserved for internal use.
@@ -181,7 +178,7 @@ struct ckx_token_type_hash
     }
 };
 
-saber_string to_string_helper(saber_ptr<ckx_token> _token);
+saber_string to_string_helper(ckx_token _token);
 
 } // namespace ckx
 

--- a/compiler/ckx_token_stream.hpp
+++ b/compiler/ckx_token_stream.hpp
@@ -32,8 +32,6 @@
 namespace ckx
 {
 
-using saber::saber_ptr;
-
 namespace detail
 {
 class ckx_token_stream_impl;
@@ -46,7 +44,7 @@ public:
     explicit ckx_token_stream(we::we_file_reader &_file_reader);
     ~ckx_token_stream();
 
-    saber_ptr<ckx_token> operator[] (int _offset);
+    ckx_token operator[] (int _offset);
     saber::vector<ckx_error>& get_error();
     void operator++ ();
 

--- a/saber/include/memory.hpp
+++ b/saber/include/memory.hpp
@@ -181,8 +181,7 @@ public:
     saber_ptr(T* _ptr) :
         ptr(_ptr),
         shared_count(new size_t(1))
-    {
-    }
+    {}
 
     saber_ptr(const saber_ptr& _another) :
         ptr(_another.ptr),


### PR DESCRIPTION
1. use ckx_token and pass-by-value directly, instead of using saber_ptr. this may decrease malloc traffic and somehow improve efficiency.
2. making ckx_token immutable.